### PR TITLE
Add CLI support and optional PyQt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # scan2
 
+This repository provides a network scanner and brute-force tool. The original `main.py` starts a Qt GUI which requires a graphical environment. A lightweight command line interface is now available via `cli.py` for environments without GUI support.
+
+## Usage
+
+```
+python cli.py TARGET -p PORTS [--tool {Nmap,Masscan}] [--speed {Slow (Stealth),Normal,Fast,Aggressive}]
+```
+
+Example:
+
+```
+python cli.py 192.168.1.0/24 -p 22,80 -t Nmap
+```
+
+The script attempts to locate `nmap` or `masscan` in your `PATH`. If the required scanner is not found, an error message is displayed.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,79 @@
+import argparse
+import os
+from network_scanner import NetworkScanner
+
+
+def log(level, message):
+    print(f"[{level}] {message}")
+
+
+def find_nmap():
+    nmap_exe = "nmap.exe" if os.name == "nt" else "nmap"
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        full_path = os.path.join(path, nmap_exe)
+        if os.path.isfile(full_path):
+            return full_path
+    common_paths = [
+        "/usr/bin/nmap",
+        "/usr/local/bin/nmap",
+        "C:\\Program Files (x86)\\Nmap\\nmap.exe",
+        "C:\\Program Files\\Nmap\\nmap.exe",
+    ]
+    for path in common_paths:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def find_masscan():
+    if os.name == "nt":
+        candidates = [
+            "C:\\Program Files\\Masscan\\masscan.exe",
+            "C:\\Program Files (x86)\\Masscan\\masscan.exe",
+            "C:\\masscan\\masscan.exe",
+        ]
+        exe_name = "masscan.exe"
+    else:
+        candidates = ["/usr/bin/masscan", "/usr/local/bin/masscan"]
+        exe_name = "masscan"
+
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        full_path = os.path.join(path, exe_name)
+        if os.path.isfile(full_path):
+            return full_path
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Network Scanner CLI")
+    parser.add_argument("target", help="IP, CIDR range, or file path of targets")
+    parser.add_argument("-p", "--ports", required=True, help="Ports to scan")
+    parser.add_argument("-t", "--tool", choices=["Nmap", "Masscan"], default="Nmap")
+    parser.add_argument(
+        "-s",
+        "--speed",
+        choices=["Slow (Stealth)", "Normal", "Fast", "Aggressive"],
+        default="Normal",
+    )
+    args = parser.parse_args()
+
+    nmap_path = find_nmap()
+    masscan_path = find_masscan()
+    if args.tool == "Nmap" and not nmap_path:
+        log("Error", "Nmap not found in PATH")
+        return
+    if args.tool == "Masscan" and not masscan_path:
+        log("Error", "Masscan not found in PATH")
+        return
+
+    scanner = NetworkScanner(nmap_path, masscan_path, log)
+    results = scanner.scan_network(args.target, args.ports, args.tool, args.speed)
+    for ip, port, service in results:
+        print(f"{ip}:{port} {service}")
+
+
+if __name__ == "__main__":
+    main()

--- a/error_handler.py
+++ b/error_handler.py
@@ -1,6 +1,10 @@
 import traceback
-from PyQt5.QtWidgets import QMessageBox
 import subprocess
+
+try:
+    from PyQt5.QtWidgets import QMessageBox
+except Exception:
+    QMessageBox = None
 
 class ErrorHandler:
     def __init__(self, log_function):
@@ -46,7 +50,10 @@ class ErrorHandler:
             print(f"Error handling failed: {str(e)}")
     
     def show_warning(self, title, message):
-        try:
-            QMessageBox.warning(None, title, message)
-        except:
-            pass
+        if QMessageBox is not None:
+            try:
+                QMessageBox.warning(None, title, message)
+            except Exception:
+                print(f"{title}: {message}")
+        else:
+            print(f"{title}: {message}")


### PR DESCRIPTION
## Summary
- add `cli.py` to run the scanner without a GUI
- document the new command line interface in README
- update `ErrorHandler` to work without PyQt so CLI can be used in headless setups

## Testing
- `pytest -q`
- `python cli.py -h`
- `python cli.py 127.0.0.1 -p 80` *(fails: Nmap not found)*

------
https://chatgpt.com/codex/tasks/task_b_6874f42554b483278198462d4866621c