### PR TITLE
Add DISPLAY check before launching GUI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,19 @@
-from gui import NetworkScannerGUI
+import os
 import sys
-from PyQt5.QtWidgets import QApplication
+
+try:
+    from PyQt5.QtWidgets import QApplication
+except Exception as e:  # noqa: PIE786
+    print("PyQt5 is required to launch the GUI: {}".format(e))
+    sys.exit(1)
+
+from gui import NetworkScannerGUI
 
 if __name__ == "__main__":
+    if not os.environ.get("DISPLAY") and sys.platform != "win32":
+        print("Error: No DISPLAY environment variable; GUI cannot start.")
+        sys.exit(1)
+
     app = QApplication(sys.argv)
     window = NetworkScannerGUI()
     window.show()


### PR DESCRIPTION
## Summary
- catch missing PyQt5 at startup
- ensure GUI only launches when a DISPLAY is available

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` (fails gracefully without DISPLAY)


------
https://chatgpt.com/codex/tasks/task_b_6874f42554b483278198462d4866621c