### PR TITLE
Add CLI mode for headless environments

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,44 @@
-from gui import NetworkScannerGUI
+import argparse
+import os
+import shutil
 import sys
+
 from PyQt5.QtWidgets import QApplication
 
+from gui import NetworkScannerGUI
+from network_scanner import NetworkScanner
+
+
+def run_cli() -> None:
+    """Simple command-line interface for headless usage."""
+    parser = argparse.ArgumentParser(description="Network Scanner CLI")
+    parser.add_argument("--target", required=True, help="Target IP, CIDR, or file")
+    parser.add_argument("--port", required=True, help="Ports to scan")
+    parser.add_argument("--scan-tool", choices=["Nmap", "Masscan"], default="Nmap")
+    parser.add_argument("--scan-speed", default="Normal", help="Scan speed preset")
+    args = parser.parse_args()
+
+    def log(source: str, message: str) -> None:
+        print(f"[{source}] {message}")
+
+    nmap_path = shutil.which("nmap")
+    masscan_path = shutil.which("masscan")
+
+    scanner = NetworkScanner(nmap_path, masscan_path, log)
+    results = scanner.scan_network(args.target, args.port, args.scan_tool, args.scan_speed)
+    for r in results:
+        print(r)
+
+
 if __name__ == "__main__":
-    app = QApplication(sys.argv)
-    window = NetworkScannerGUI()
-    window.show()
-    sys.exit(app.exec_())
+    if "--cli" in sys.argv:
+        sys.argv.remove("--cli")
+        run_cli()
+    else:
+        if os.name != "nt" and not os.environ.get("DISPLAY"):
+            print("Error: GUI requires a display. Use --cli for command-line mode.")
+            sys.exit(1)
+        app = QApplication(sys.argv)
+        window = NetworkScannerGUI()
+        window.show()
+        sys.exit(app.exec_())


### PR DESCRIPTION
## Summary
- detect headless environment and provide a `--cli` option
- implement simple command-line interface for scanning

## Testing
- `python3 main.py --cli --target 127.0.0.1 --port 80`
- `python3 main.py`

------
https://chatgpt.com/codex/tasks/task_b_6874f42554b483278198462d4866621c